### PR TITLE
Fix for apache on windows

### DIFF
--- a/exchange.php
+++ b/exchange.php
@@ -269,6 +269,7 @@ function wc1c_mode_file($type, $filename) {
     $temp_file = fopen($temp_path, 'r');
     $file = fopen($path, 'a');
     stream_copy_to_stream($temp_file, $file);
+    fclose($temp_file);
     unlink($temp_path);
   }
 


### PR DESCRIPTION
fix to run on apache in windows

log:
```bash
PHP Unknown Error: unlink(D:\htdocs/wp-content/uploads/woocommerce-1c/catalog/v8_a14d_1f.zip~): Permission denied in D:\htdocs\wp-content\plugins\woocommerce-and-1centerprise-data-exchange\exchange.php on line 272.
```