### PR TITLE
Add WC1C_OUTOFSTOCK_STATUS

### DIFF
--- a/exchange.php
+++ b/exchange.php
@@ -5,6 +5,7 @@ if (!defined('WC1C_SUPPRESS_NOTICES')) define('WC1C_SUPPRESS_NOTICES', false);
 if (!defined('WC1C_FILE_LIMIT')) define('WC1C_FILE_LIMIT', null);
 if (!defined('WC1C_XML_CHARSET')) define('WC1C_XML_CHARSET', 'UTF-8');
 if (!defined('WC1C_DISABLE_VARIATIONS')) define('WC1C_DISABLE_VARIATIONS', false);
+if (!defined('WC1C_OUTOFSTOCK_STATUS')) define('WC1C_OUTOFSTOCK_STATUS', 'outofstock');
 define('WC1C_TIMESTAMP', time());
 
 function wc1c_query_vars($query_vars) {

--- a/exchange/import.php
+++ b/exchange/import.php
@@ -192,7 +192,7 @@ function wc1c_import_end_element_handler($is_full, $names, $depth, $name) {
         $_product = wc_get_product($_post_id);
         $_qnty = $_product->get_stock_quantity();
         if (!$_qnty) {
-          update_post_meta($_post_id, '_stock_status', 'outofstock');
+          update_post_meta($_post_id, '_stock_status', WC1C_OUTOFSTOCK_STATUS);
         }
         unset($_product, $_qnty);
       }
@@ -675,7 +675,7 @@ function wc1c_replace_product($is_full, $guid, $product) {
   //   if (isset($product['Пересчет']['Коэффициент'])) $quantity *= wc1c_parse_decimal($product['Пересчет']['Коэффициент']);
   //   wc_update_product_stock($post_id, $quantity);
   //
-  //   $stock_status = $quantity > 0 ? 'instock' : 'outofstock';
+  //   $stock_status = $quantity > 0 ? 'instock' : WC1C_OUTOFSTOCK_STATUS;
   //   wc_update_product_stock_status($post_id, $stock_status);
   // }
 

--- a/exchange/offers.php
+++ b/exchange/offers.php
@@ -85,7 +85,7 @@ function wc1c_offers_end_element_handler($is_full, $names, $depth, $name) {
         $_product = wc_get_product($_post_id);
         $_qnty = $_product->get_stock_quantity();
         if (!$_qnty) {
-          update_post_meta($_post_id, '_stock_status', 'outofstock');
+          update_post_meta($_post_id, '_stock_status', WC1C_OUTOFSTOCK_STATUS);
         }
         unset($_product, $_qnty);
       }
@@ -199,7 +199,7 @@ function wc1c_replace_offer_post_meta($is_full, $post_id, $offer, $attributes = 
     $quantity = wc1c_parse_decimal($quantity);
     wc_update_product_stock($post_id, $quantity);
 
-    $stock_status = $quantity > 0 ? 'instock' : 'outofstock';
+    $stock_status = $quantity > 0 ? 'instock' : WC1C_OUTOFSTOCK_STATUS;
     @wc_update_product_stock_status($post_id, $stock_status);
   }
 


### PR DESCRIPTION
That gives ability to set products onbackorder status instead of outofstock.

For example my store produce products after placing an order and confirming, so I don't have any of my products in stock, but want them to be published and available to order on my site.