### PR TITLE
Fix of client's contacts

### DIFF
--- a/exchange/query.php
+++ b/exchange/query.php
@@ -212,7 +212,7 @@ echo '<?xml version="1.0" encoding="' . WC1C_XML_CHARSET . '"?>';
                 <?php endforeach ?>
               </АдресРегистрации>
             <?php endif ?>
-			<?php if (defined('WC1C_CLIENT_CONTACT_TYPE')): ?>
+            <?php if (defined('WC1C_CLIENT_CONTACT_TYPE')): ?>
             <Контакты>
               <?php foreach ($contragent['contacts'] as $contact_item_name => $contact_item_value): ?>
                 <Контакт>
@@ -221,7 +221,7 @@ echo '<?xml version="1.0" encoding="' . WC1C_XML_CHARSET . '"?>';
                 </Контакт>
               <?php endforeach ?>
             </Контакты>
-			<?php endif ?>
+            <?php endif ?>
             <?php /*
             <Представители>
               <Представитель>

--- a/exchange/query.php
+++ b/exchange/query.php
@@ -212,15 +212,17 @@ echo '<?xml version="1.0" encoding="' . WC1C_XML_CHARSET . '"?>';
                 <?php endforeach ?>
               </АдресРегистрации>
             <?php endif ?>
-            <?php /*
+			<?php if (defined('WC1C_CLIENT_CONTACT_TYPE')): ?>
             <Контакты>
               <?php foreach ($contragent['contacts'] as $contact_item_name => $contact_item_value): ?>
                 <Контакт>
-                  <КонтактВид><?php echo $contact_item_name ?></КонтактВид>
+                  <<?php echo WC1C_CLIENT_CONTACT_TYPE; ?>><?php echo $contact_item_name ?></<?php echo WC1C_CLIENT_CONTACT_TYPE; ?>>
                   <Значение><?php echo $contact_item_value ?></Значение>
                 </Контакт>
               <?php endforeach ?>
             </Контакты>
+			<?php endif ?>
+            <?php /*
             <Представители>
               <Представитель>
                 <Контрагент>

--- a/exchange/query.php
+++ b/exchange/query.php
@@ -212,16 +212,14 @@ echo '<?xml version="1.0" encoding="' . WC1C_XML_CHARSET . '"?>';
                 <?php endforeach ?>
               </АдресРегистрации>
             <?php endif ?>
-            <?php if (defined('WC1C_CLIENT_CONTACT_TYPE')): ?>
             <Контакты>
               <?php foreach ($contragent['contacts'] as $contact_item_name => $contact_item_value): ?>
                 <Контакт>
-                  <<?php echo WC1C_CLIENT_CONTACT_TYPE; ?>><?php echo $contact_item_name ?></<?php echo WC1C_CLIENT_CONTACT_TYPE; ?>>
+                  <Тип><?php echo $contact_item_name ?></Тип>
                   <Значение><?php echo $contact_item_value ?></Значение>
                 </Контакт>
               <?php endforeach ?>
             </Контакты>
-            <?php endif ?>
             <?php /*
             <Представители>
               <Представитель>


### PR DESCRIPTION
According to [this](https://www.cs-cart.ru/docs/4.3.x/developer/1c/ordersxml.html?highlight=%D0%BA%D0%BE%D0%BD%D1%82%D0%B0%D0%BA%D1%82%D1%8B#id4), tag for client's contact type items should be `Тип` instead of `КонтактВид`