### PR TITLE
Correct full_name generation

### DIFF
--- a/exchange/query.php
+++ b/exchange/query.php
@@ -63,7 +63,7 @@ foreach ($order_posts as $order_post) {
     $contragent = array();
 
     $name = array();
-    foreach (array('first_name', 'last_name') as $name_key) {
+    foreach (array('last_name', 'first_name') as $name_key) {
       $meta_key = "_{$type}_$name_key";
       if (empty($order_meta[$meta_key])) continue;
 


### PR DESCRIPTION
As 1С expects Контрагент's Наименование as ФИО, it looks like last_name should take first place.