### PR TITLE
Фикс ошибки "Failed open archive %s with error code 19" при распаковке архива

### DIFF
--- a/exchange.php
+++ b/exchange.php
@@ -325,6 +325,7 @@ function wc1c_unpack_files($type) {
   $data_dir = WC1C_DATA_DIR . $type;
   $zip_paths = glob("$data_dir/*.zip");
   if (!$zip_paths) return;
+  ob_end_clean();
 
   $command = sprintf("unzip -qqo -x %s -d %s", implode(' ', array_map('escapeshellarg', $zip_paths)), escapeshellarg($data_dir));
   @exec($command, $_, $status);


### PR DESCRIPTION
При обмене данными с архивом большого размера, возникает ошибка

<img width="916" alt="error" src="https://user-images.githubusercontent.com/12444363/86083166-b9fd5d80-bac3-11ea-98d5-f4de4543fa74.png">

> Failed open archive %s with error code 19

Данный PR решает эту проблему путем добавления системной функции **ob_end_clean** перед распаковкой архива.