### PR TITLE
Статус продукта теперь передаётся в $wc1c_product

### DIFF
--- a/exchange/import.php
+++ b/exchange/import.php
@@ -54,6 +54,9 @@ function wc1c_import_start_element_handler($is_full, $names, $depth, $name, $att
       'ЗначенияСвойств' => array(),
       'ЗначенияРеквизитов' => array(),
     );
+    if (isset($attrs['Статус'])) {
+      $wc1c_product['Статус'] = $attrs['Статус'];
+    }
   }
   elseif (@$names[$depth - 1] == 'Товар' && $name == 'Группы') {
     $wc1c_product['Группы'] = array();


### PR DESCRIPTION
В wc1c_replace_product проверяется статус продукта,
    $is_deleted = @$product['Статус'] == 'Удален';
    $is_draft = @$product['Статус'] == 'Черновик';
Но это было бесполезно, поскольку в wc1c_import_start_element_handler статус не устанавливался.