### PR TITLE
Исправление генерации айдишника контрагента

### DIFF
--- a/exchange/query.php
+++ b/exchange/query.php
@@ -78,7 +78,7 @@ foreach ($order_posts as $order_post) {
     }
     else {
       $contragent['name'] = $name;
-      $contragent['user_id'] = $order_post->post_author;
+      $contragent['user_id'] = $order->get_customer_id();
     }
 
     if (!empty($order_meta["_{$type}_country"])) {


### PR DESCRIPTION
По умолчанию, если это не меняется плагинами, автором заказа является пользователь ID=1.
https://woocommerce.github.io/code-reference/files/woocommerce-includes-data-stores-abstract-wc-order-data-store-cpt.html#source-view.74
Так что $order_post->post_author == 1 и айдишник контрагента всегода wc1c#user#1.
Чтобы передавался айдишник заказчика, надо использовать get_customer_id().